### PR TITLE
Bump up supported node versions to 14, 16, and 18

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019, macos-latest]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "nbsdecoder.js",
   "types": "nbsdecoder.d.ts",
   "engines": {
-    "node": "~10 >=10.20 || >=12.17"
+    "node": ">=14.14.0"
   },
   "files": [
     "nbsdecoder.js",


### PR DESCRIPTION
Upgrade the supported node versions since 12.x is no longer supported. Functionality for the Encoder also depends on functions added in 14.x ([fs.rmSync](https://nodejs.org/api/fs.html#fsrmsyncpath-options)). 