### PR TITLE
Fix loss of precision when converting a JS timestamp object to `uint64_t`

### DIFF
--- a/src/Timestamp.cpp
+++ b/src/Timestamp.cpp
@@ -30,7 +30,7 @@ namespace nbs {
                 uint64_t seconds = ts.Get("seconds").As<Napi::Number>().Int64Value();
                 uint64_t nanos   = ts.Get("nanos").As<Napi::Number>().Int64Value();
 
-                timestamp = seconds * 1e9 + nanos;
+                timestamp = seconds * 1000000000L + nanos;
             }
             else {
                 throw std::runtime_error("expected positive number or BigInt or timestamp object");


### PR DESCRIPTION
The conversion of a JS timestamp object of `nanos` and `seconds` to a single `uint64_t` value currently uses `1e9` as a multiplier. This causes the conversion to be done with doubles, with the result implicitly converted to a `uint64_t`, leading to a loss of precision in certain cases.

This PR uses the literal `1000000000L` instead of the scientific notation, ensuring the conversion is done with integers.